### PR TITLE
Bump prettier and fix parser warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "import-local": "^0.1.1",
         "meow": "^3.7.0",
         "pify": "^3.0.0",
-        "prettier": "^1.7.0",
+        "prettier": "^1.8.2",
         "resolve-from": "^4.0.0",
         "stylelint": "^8.1.1",
         "temp-write": "^3.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ resolveConfig.resolve = (stylelintConfig, prettierOptions = {}) => {
             prettierOptions.tabWidth = indentation;
         }
     }
-    prettierOptions.parser = 'postcss';
+    prettierOptions.parser = 'css';
     debug('prettier %O', prettierOptions);
     debug('linter %O', stylelintConfig);
 

--- a/test.js
+++ b/test.js
@@ -224,11 +224,11 @@ test('resolve relative package deep', (t) => {
 test('resolve relative package fallback', (t) => {
     const path = resolveFrom('./fixtures/style.css', 'prettier');
 
-    t.is('1.7.0', require(path).version);
+    t.is('1.8.2', require(path).version);
 });
 
 test('resolve relative package null', (t) => {
     const path = resolveFrom(__filename, 'prettier');
 
-    t.is('1.7.0', require(path).version);
+    t.is('1.8.2', require(path).version);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3627,9 +3627,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
+prettier@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
 
 pretty-ms@^0.2.1:
   version "0.2.2"


### PR DESCRIPTION
This PR fixes https://github.com/hugomrdias/prettier-stylelint/issues/3, and fixes https://github.com/hugomrdias/prettier-stylelint/issues/5.

As per this [comment](https://github.com/prettier/prettier/pull/2844#issuecomment-331938602): `deprecated postcss in favor of css`. 

### Before 
* using postcss, we see the warnings: 
![screen shot 2017-11-07 at 4 49 25 pm](https://user-images.githubusercontent.com/6130700/32519995-85812d74-c3dc-11e7-96b1-516bffdcc238.png)


### After
*  with css, no warnings: 
![screen shot 2017-11-07 at 4 53 34 pm](https://user-images.githubusercontent.com/6130700/32519992-8277845c-c3dc-11e7-82ad-2a0c02a6f798.png)
