### PR TITLE
Fix null prettier options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="0.5.1-beta.1"></a>
+## [0.5.1-beta.1](https://github.com/ismail-syed/prettier-stylelint-formatter/compare/v0.5.0...v0.5.1-beta.1) (2018-04-13)
+
+
+
 <a name="0.5.0"></a>
 # [0.5.0](https://github.com/ismail-syed/prettier-stylelint-formatter/compare/v0.4.2...v0.5.0) (2017-11-15)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-stylelint-formatter",
-    "version": "0.5.0",
+    "version": "0.5.1-beta.1",
     "description": "fork of hugomrdias/prettier-stylelint",
     "repository": "ismail-syed/prettier-stylelint-formatter",
     "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "scripts": {
         "test": "nyc ava",
         "lint": "eslint --cache *.js src/*.js",
-        "validate": "run-p lint test",
-        "precommit": "yarn validate",
+        "validate": "yarn run lint && yarn run test",
         "version": "yarn changelog && git add CHANGELOG.md",
         "cov": "yarn test && nyc report --reporter=html && hs coverage -s -o -c-1",
         "cov:report": "nyc report --reporter=text-lcov > coverage.lcov && codecov",

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,11 @@ function resolveConfig({
 }
 
 resolveConfig.resolve = (stylelintConfig, prettierOptions = {}) => {
+    //  prettier.resolveConfig.sync(filePath) returns null at if a project doesn't have a prettier config
+    if (prettierOptions === null) {
+        prettierOptions = {};
+    }
+
     const { rules } = stylelintConfig;
 
     if (rules['max-line-length']) {


### PR DESCRIPTION
If a prettier config is not set in a project, the `pretteriOptions` param receives null. This adds guard to fix that.  Bit of a hack but works... :/