### PR TITLE
Infer parser instead of hardcoding it

### DIFF
--- a/fixtures/trailing-comma/.prettierrc
+++ b/fixtures/trailing-comma/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "all"
+}

--- a/fixtures/trailing-comma/scss.scss
+++ b/fixtures/trailing-comma/scss.scss
@@ -1,0 +1,5 @@
+$greek: (
+alpha: 100,
+beta: 200,
+gamma: 300
+);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "import-local": "^0.1.1",
         "meow": "^3.7.0",
         "pify": "^3.0.0",
-        "prettier": "^1.8.2",
+        "prettier": "^1.13.6",
         "resolve-from": "^4.0.0",
         "stylelint": "^8.1.1",
         "temp-write": "^3.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -33,11 +33,6 @@ function resolveConfig({
 }
 
 resolveConfig.resolve = (stylelintConfig, prettierOptions = {}) => {
-    //  prettier.resolveConfig.sync(filePath) returns null at if a project doesn't have a prettier config
-    if (prettierOptions === null) {
-        prettierOptions = {};
-    }
-
     const { rules } = stylelintConfig;
 
     if (rules['max-line-length']) {
@@ -65,7 +60,6 @@ resolveConfig.resolve = (stylelintConfig, prettierOptions = {}) => {
             prettierOptions.tabWidth = indentation;
         }
     }
-    prettierOptions.parser = 'css';
     debug('prettier %O', prettierOptions);
     debug('linter %O', stylelintConfig);
 
@@ -104,10 +98,16 @@ function getPrettierConfig(filePath, prettierPath) {
     const prettier = requireRelative(prettierPath, filePath, 'prettier');
 
     // NOTE: Backward-compatibility with old prettier versions (<1.7)
-    //       that don't have ``resolveConfig.sync` method.
+    // that don't have `resolveConfig.sync` method.
+    // prettier.resolveConfig.sync(filePath) returns null at if a project
+    // doesn't have a prettier config
+    // Add filepath as prettier does not currently include that in the resolved
+    // configuration. `filepath` eventually gets used as a hint for which
+    // parser to use within prettier
+
     return typeof prettier.resolveConfig.sync === 'undefined' ?
         {} :
-        prettier.resolveConfig.sync(filePath);
+        Object.assign({}, prettier.resolveConfig.sync(filePath) || {}, {filepath: filePath});
 }
 
 function format({

--- a/test.js
+++ b/test.js
@@ -79,7 +79,18 @@ test('resolveConfig prettier merge', t =>
         t.is(config[0].semi, false);
 
         return config;
-    }));
+    })
+);
+
+test('resolveConfig contains filepath', t =>
+    resolveConfig({
+        filePath: './fixtures/style.css',
+        prettierOptions: getPrettierConfig('./fixtures/style.css')
+    }).then((config) => {
+        t.is(config[0].filepath, './fixtures/style.css');
+        return config;
+    })
+);
 
 test('format', (t) => {
     const source = fs.readFileSync('./fixtures/style.css', 'utf8');

--- a/test.js
+++ b/test.js
@@ -217,6 +217,26 @@ a[id="foo"] { content: "x"; }
         });
 });
 
+test('format scss uses the right parser', (t) => {
+    const filePath = './fixtures/trailing-comma/scss.scss';
+    const source = fs.readFileSync(filePath, 'utf8');
+
+    return format({
+        text: source,
+        filePath: filePath
+    }).then((source) => {
+        t.is(source,
+            `$greek: (
+alpha: 100,
+beta: 200,
+gamma: 300,
+);
+`);
+
+        return source;
+    });
+});
+
 test('resolve relative package', (t) => {
     const path = resolveFrom('./fixtures/find-package/style.css', 'prettier');
 
@@ -235,11 +255,11 @@ test('resolve relative package deep', (t) => {
 test('resolve relative package fallback', (t) => {
     const path = resolveFrom('./fixtures/style.css', 'prettier');
 
-    t.is('1.8.2', require(path).version);
+    t.is('1.13.6', require(path).version);
 });
 
 test('resolve relative package null', (t) => {
     const path = resolveFrom(__filename, 'prettier');
 
-    t.is('1.8.2', require(path).version);
+    t.is('1.13.6', require(path).version);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3627,9 +3627,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
+prettier@^1.13.6:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.6.tgz#00ae0b777ad92f81a9e7a1df2f0470b6dab0cb44"
 
 pretty-ms@^0.2.1:
   version "0.2.2"


### PR DESCRIPTION
Pass the filepath into prettier's options. This allows prettier to infer the correct parser for a given file rather than hardcoding everything to use the css parser. This means that .scss files shall be formatted using the scss parser rather than the css parser. And thus parser-specific formatting such as trailing commas in lists shall be output correctly.

Annoyingly this requires updating prettier as scss-parser specific
functionality was added in 1.13 and I don't know of any examples in
earlier versions.
